### PR TITLE
Fix errors resulting from quick-xml version bump

### DIFF
--- a/src/level2/ext/mod.rs
+++ b/src/level2/ext/mod.rs
@@ -23,4 +23,3 @@ pub(crate) mod traits;
 pub use traits::*;
 
 pub(crate) mod trait_impls;
-pub use trait_impls::*;


### PR DESCRIPTION
# Description

Commit https://github.com/johnstonskj/rust-xml_dom/commit/7891c92d58923020a976c799eb6b8a2463ffd011 broke the build, as the new version of `quick-xml` had breaking changes. This PR fixes those compilation issues.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

`cargo test --all-features` is passing.

**Environment (please complete the following information):**
 - Platform: `Linux ArchLaptop 6.1.12-arch1-1 #1 SMP PREEMPT_DYNAMIC Tue, 14 Feb 2023 22:08:08 +0000 x86_64 GNU/Linux`
 - Rust:
 ```
 rustc 1.69.0-nightly (c5c7d2b37 2023-02-24)
binary: rustc
commit-hash: c5c7d2b37780dac1092e75f12ab97dd56c30861d
commit-date: 2023-02-24
host: x86_64-unknown-linux-gnu
release: 1.69.0-nightly
LLVM version: 15.0.7
```
 - Cargo [e.g.`cargo -vV`]:
 ```
 cargo 1.69.0-nightly (9d5b32f50 2023-02-22)
release: 1.69.0-nightly
commit-hash: 9d5b32f503fc099c4064298465add14d4bce11e6
commit-date: 2023-02-22
host: x86_64-unknown-linux-gnu
libgit2: 1.5.0 (sys:0.16.0 vendored)
libcurl: 7.86.0-DEV (sys:0.4.59+curl-7.86.0 vendored ssl:OpenSSL/1.1.1q)
os: Arch Linux Rolling Release [64-bit]
```

# Checklist:

- [X] My code follows the style guidelines of this project (e.g. run `cargo fmt`)
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] My changes DO NOT require unstable features without prior agreement
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
