### PR TITLE
performance improvement: compile regular expressions in text.rs at most once

### DIFF
--- a/src/level2/ext/mod.rs
+++ b/src/level2/ext/mod.rs
@@ -23,4 +23,3 @@ pub(crate) mod traits;
 pub use traits::*;
 
 pub(crate) mod trait_impls;
-pub use trait_impls::*;

--- a/src/shared/text.rs
+++ b/src/shared/text.rs
@@ -2,6 +2,7 @@ use crate::shared::syntax::*;
 use std::convert::TryFrom;
 use std::fmt::{Display, Formatter, Result as FmtResult};
 use std::str::FromStr;
+use std::sync::OnceLock;
 
 // ------------------------------------------------------------------------------------------------
 //  Public Types
@@ -69,10 +70,11 @@ pub(crate) fn normalize_attribute_value(
     let step_3 = if step_1.is_empty() {
         step_1
     } else {
-        let find = regex::Regex::new(
+        static FIND: OnceLock<regex::Regex> = OnceLock::new();
+        let find = FIND.get_or_init(|| {regex::Regex::new(
             r"(?P<entity_ref>[&%][\pL_][\pL\.\d_\-]*;)|(?P<char>&#\d+;)|(?P<char_hex>&#x[0-9a-fA-F]+;)|(?P<ws>[\u{09}\u{0A}\u{0D}])",
         )
-        .unwrap();
+        .unwrap()});
         let mut step_2 = String::new();
         let mut last_end = 0;
         for capture in find.captures_iter(&step_1) {
@@ -141,7 +143,9 @@ pub(crate) fn normalize_end_of_lines(value: &str) -> String {
     if value.is_empty() {
         value.to_string()
     } else {
-        let line_ends = regex::Regex::new(r"\u{0D}[\u{0A}\u{85}]?|\u{85}|\u{2028}").unwrap();
+        static LINE_ENDS: OnceLock<regex::Regex> = OnceLock::new();
+        let line_ends = LINE_ENDS
+            .get_or_init(|| regex::Regex::new(r"\u{0D}[\u{0A}\u{85}]?|\u{85}|\u{2028}").unwrap());
         line_ends.replace_all(value, "\u{0A}").to_string()
     }
 }


### PR DESCRIPTION
# Description

Regular expressions in `text.rs` is compiled every time when the corresponding method calls, and thus causes performance issues.
I modified it to compile regular expressions in `text.rs` at most once using `OnceLock`.

This PR also includes changes from https://github.com/johnstonskj/rust-xml_dom/pull/16 ,  because the build of the current main branch fails without that change.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Passed `cargo test`
- [x] Performance improvement is observed from codes below:
```
fn main() {
    let implementation = get_implementation();
    let mut document_node = implementation
        .create_document(Some("http://www.w3.org/1999/xhtml"), Some("html"), None)
        .unwrap();

    let document = as_document_mut(&mut document_node).unwrap();
    let mut root_node = document.document_element().unwrap();
    
    let root = as_element_mut(&mut root_node).unwrap();
    for _ in 0..100_000 {
        let mut c = root.append_child(document.create_element("head").unwrap()).unwrap();
        c.set_attribute("attr1", "value1").unwrap();
    }
    
    let xml = document_node.to_string();
    println!("document: {}", xml);
}
```
With xml_dom v0.2.6, this program takes about 50 seconds to execute even in a release build on my local machine.
With this PR's change, the program takes less than 1 second.


**Environment (please complete the following information):**
 - Platform: `Darwin LF2310010023 23.4.0 Darwin Kernel Version 23.4.0: Wed Feb 21 21:51:37 PST 2024; root:xnu-10063.101.15~2/RELEASE_ARM64_T8112 arm64`
 - Rust:
  ```
 rustc 1.77.2 (25ef9e3d8 2024-04-09)
binary: rustc
commit-hash: 25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04
commit-date: 2024-04-09
host: aarch64-apple-darwin
release: 1.77.2
LLVM version: 17.0.6
```
 - Cargo 
```
cargo 1.77.2 (e52e36006 2024-03-26)
release: 1.77.2
commit-hash: e52e360061cacbbeac79f7f1215a7a90b6f08442
commit-date: 2024-03-26
host: aarch64-apple-darwin
libgit2: 1.7.2 (sys:0.18.2 vendored)
libcurl: 8.4.0 (sys:0.4.70+curl-8.5.0 system ssl:(SecureTransport) LibreSSL/3.3.6)
ssl: OpenSSL 1.1.1w  11 Sep 2023
os: Mac OS 14.4.0 [64-bit]
```

# Checklist:

- [x] My code follows the style guidelines of this project (e.g. run `cargo fmt`)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes DO NOT require unstable features without prior agreement
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
