### PR TITLE
Updated and genericized a few interfaces.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xml_dom"
-version = "0.2.6"
+version = "0.2.7"
 authors = ["Simon Johnston <johnstonskj@gmail.com>"]
 edition = "2021"
 description = "A Rust crate providing a reasonably faithful implementation of the W3C DOM Core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "xml_dom"
 version = "0.2.6"
 authors = ["Simon Johnston <johnstonskj@gmail.com>"]
-edition = "2018"
+edition = "2021"
 description = "A Rust crate providing a reasonably faithful implementation of the W3C DOM Core"
 documentation = "https://docs.rs/xml_dom/"
 repository = "https://github.com/johnstonskj/rust-xml_dom.git"
@@ -25,7 +25,8 @@ quick_parser = ["quick-xml"]
 
 [dependencies]
 log = "0.4"
-regex = "1.6"
+regex = "1.10"
 
 # Feature specific dependencies
-quick-xml = { optional = true, version = "0.26" }
+quick-xml = { optional = true, version = "0.31" }
+thiserror = "1.0.59"

--- a/README.md
+++ b/README.md
@@ -95,6 +95,15 @@ This will parse the document and return a new `RefNode` that corresponds to the 
 
 ## Changes
 
+### Version 0.2.7
+
+* Updated to 2021 Edition of Rust
+* Updated [quick-xml](https://crates.io/crates/quick-xml) dependency.
+* Refactored `Error` type with [thiserror](https://crates.io/crates/thiserror)
+  * Encapsulated errors from dependant libraries and removed manual `From` implementations.
+  * Removed unused `Error` enum types.
+* Made several interfaces more generic with `AsRef<str>` and `Into<String>`.
+
 ### Version 0.2.6
 
 * Updated [quick-xml](https://crates.io/crates/quick-xml) dependency.
@@ -103,8 +112,7 @@ This will parse the document and return a new `RefNode` that corresponds to the 
 
 ### Version 0.2.5
 
-* Added `parser::from_reader` function alongside the existing `parser::from_str` to allow for streaming input
-  of the underlying source.
+* Added `parser::from_reader` function alongside the existing `parser::from_str` to allow for streaming input of the underlying source.
 
 ### Version 0.2.4
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Crate xml_dom
 
-A Rust crate providing a reasonably faithful implementation of the  W3C 
+A Rust crate providing a reasonably faithful implementation of the  W3C
 [Document Object Model Core, Level 2](https://www.w3.org/TR/DOM-Level-2-Core).
 
 ![MIT License](https://img.shields.io/badge/license-mit-118811.svg)
@@ -43,7 +43,7 @@ let document_type = implementation
     )
     .unwrap();
 
-// Create a new `Document` using the document type defined above. Note that this 
+// Create a new `Document` using the document type defined above. Note that this
 // also has the side-effect of creating the document's root element named "html".
 let mut document_node = implementation
     .create_document(Some("http://www.w3.org/1999/xhtml"), Some("html"), Some(document_type))
@@ -68,13 +68,13 @@ let xml = document_node.to_string();
 println!("document 2: {}", xml);
 ```
 
-This should result in the following XML; note that formatting was added for this document, the provided 
+This should result in the following XML; note that formatting was added for this document, the provided
 implementation of `Display` for `RefNode` does not format the output.
- 
+
 ```xml
-<!DOCTYPE 
-  html 
-  PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" 
+<!DOCTYPE
+  html
+  PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
   SYSTEM "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html lang="en">
   <head></head>
@@ -88,47 +88,47 @@ Currently only one feature, `quick_parser`, is provided which provides a new mod
 single public function. This feature is enabled by default.
 
 ``` rust
-pub fn read_xml(xml: &str) -> Result<RefNode>;
+pub fn read_xml(xml: AsRef<str>) -> Result<RefNode>;
 ```
 
 This will parse the document and return a new `RefNode` that corresponds to the `Document` trait.
 
 ## Changes
 
-**Version 0.2.6**
+### Version 0.2.6
 
 * Updated [quick-xml](https://crates.io/crates/quick-xml) dependency.
   * Had to update the handling of errors from the underlying parser.
   * Had to handle the CData parser explicitly.
-  
-**Version 0.2.5**
+
+### Version 0.2.5
 
 * Added `parser::from_reader` function alongside the existing `parser::from_str` to allow for streaming input
   of the underlying source.
 
-**Version 0.2.4**
+### Version 0.2.4
 
 * Updated [quick-xml](https://crates.io/crates/quick-xml) dependency.
 * Moved TODOs into [GitHub issues](https://github.com/johnstonskj/rust-xml_dom/issues).
 * Started migration to [GitHub actions](https://github.com/johnstonskj/rust-xml_dom/actions) for build.
 
-**Version 0.2.3**
+### Version 0.2.3
 
 * Mostly documentation updates/fixes.
 * Made namespace support respect `ProcessingOptions`.
 
-**Version 0.2.2**
+### Version 0.2.2
 
 * Mostly documentation updates/fixes.
 * Fixed a defect in handling of `xml:id`.
 
-**Version 0.2.1**
+### Version 0.2.1
 
 * Bug Fixes:
   * Fixed a publishing error in Travis
   * Separated `Attribute::owner_element` from `Node::parent_node`, they aren't the same.
   * Fixed handling of `owner_element` in `Attribute` tests
-  * Fixed the implementation of `WrongDocument` error in `Node::insert_before` and used the same in 
+  * Fixed the implementation of `WrongDocument` error in `Node::insert_before` and used the same in
     `Element::set_attribute_node`.
   * Fixed escaping of values to happen on get not set.
   * Implemented _attribute value normalization_ and _end-of-line handling_ from the XML 1.1 spec.
@@ -138,13 +138,13 @@ This will parse the document and return a new `RefNode` that corresponds to the 
 * Code clean-up:
   * Added some macros in `trait_impls` for a number of common patterns.
   * Simplified some existing `match` expressions.
-  
-**Version 0.2.0** 
+
+### Version 0.2.0
 
 * Cleaned up documentation.
 * Stable release.
 
-**Version 0.1.4**
+### Version 0.1.4
 
 * **BREAKING** refactored to add a `level2` module, allowing other levels to be added at a later time. Also
   moved extensions into `level2::ext` module.
@@ -168,17 +168,17 @@ This will parse the document and return a new `RefNode` that corresponds to the 
 * Added `quick_xml` based text parser.
 * Make this the 0.2.0 candidate.
 
-**Version 0.1.3**
+### Version 0.1.3
 
 * More unit tests overall, especially for append/insert/replace child
 * Add support for xml declaration (`XmlDecl`, `XmlVersion`), not reusing processing instruction
 * Support the last Level 2 _extended interfaces_ (`Entity`, `EntityReference`, and `Notation`).
   * Also, add `create_notation`, `create_entity`, and `create_internal_entity` to `dom_impl`.
-* Implement an options (`ProcessingOptions` and `DOMImplementation::create_document_with_options`) capability to turn 
+* Implement an options (`ProcessingOptions` and `DOMImplementation::create_document_with_options`) capability to turn
   on extended processing behaviors.
 * Fixed some nested borrow issues.
 
-**Version 0.1.2**
+### Version 0.1.2
 
 * Focus on feature completion:
   * implement all core trait features
@@ -187,7 +187,7 @@ This will parse the document and return a new `RefNode` that corresponds to the 
   * refactor `NodeImpl` for extended traits
 * Unit tests, lot's of unit tests
 
-**Version 0.1.1**
+### Version 0.1.1
 
 * Focus on API, separate the traits from implementation more cleanly.
 * Better `Display` formatting
@@ -197,7 +197,7 @@ This will parse the document and return a new `RefNode` that corresponds to the 
 * More examples, fleshing out more of the common methods.
 * Note, this is NOT YET ready for production usage.
 
-**Version 0.1.0**
+### Version 0.1.0
 
 * Focus on modeling as traits, not all methods actually implemented.
 * Note, this is NOT YET ready for production usage.
@@ -207,4 +207,3 @@ This will parse the document and return a new `RefNode` that corresponds to the 
 1. [More tests required](https://github.com/johnstonskj/rust-xml_dom/issues/4).
 1. [More doc test/examples](https://github.com/johnstonskj/rust-xml_dom/issues/5).
 1. [Ensure correct notation replacement](https://github.com/johnstonskj/rust-xml_dom/issues/6).
-

--- a/examples/java_example.rs
+++ b/examples/java_example.rs
@@ -26,7 +26,7 @@ fn main() {
 }
 
 #[allow(unused_must_use)]
-fn create_user<'a>(
+fn create_user(
     doc: RefDocument,
     id: &str,
     first_name: &str,

--- a/src/level2/convert.rs
+++ b/src/level2/convert.rs
@@ -79,10 +79,10 @@ make_is_as_functions!(
 ///
 #[inline]
 pub fn is_character_data(ref_node: &RefNode) -> bool {
-    match ref_node.borrow().i_node_type {
-        NodeType::CData | NodeType::Comment | NodeType::Text => true,
-        _ => false,
-    }
+    matches!(
+        ref_node.borrow().i_node_type,
+        NodeType::CData | NodeType::Comment | NodeType::Text
+    )
 }
 
 ///

--- a/src/level2/ext/decl.rs
+++ b/src/level2/ext/decl.rs
@@ -57,13 +57,13 @@ pub struct XmlDecl {
 pub(crate) const ENCODING_SEP_CHAR: char = '-';
 
 fn is_encoding_start_char(c: char) -> bool {
-    (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')
+    c.is_ascii_uppercase() || c.is_ascii_lowercase()
 }
 
 fn is_encoding_rest_char(c: char) -> bool {
-    (c >= 'A' && c <= 'Z')
-        || (c >= 'a' && c <= 'z')
-        || (c >= '0' && c <= '9')
+    c.is_ascii_uppercase()
+        || c.is_ascii_lowercase()
+        || c.is_ascii_digit()
         || c == '.'
         || c == '_'
 }

--- a/src/level2/ext/decl.rs
+++ b/src/level2/ext/decl.rs
@@ -61,11 +61,7 @@ fn is_encoding_start_char(c: char) -> bool {
 }
 
 fn is_encoding_rest_char(c: char) -> bool {
-    c.is_ascii_uppercase()
-        || c.is_ascii_lowercase()
-        || c.is_ascii_digit()
-        || c == '.'
-        || c == '_'
+    c.is_ascii_uppercase() || c.is_ascii_lowercase() || c.is_ascii_digit() || c == '.' || c == '_'
 }
 
 fn is_encoding_sub_string(s: &str) -> bool {

--- a/src/level2/ext/decl.rs
+++ b/src/level2/ext/decl.rs
@@ -19,9 +19,9 @@ use std::str::FromStr;
 ///
 #[derive(Clone, Debug, PartialEq)]
 pub enum XmlVersion {
-    /// Version 1.0 [https://www.w3.org/TR/xml]
+    /// Version 1.0 [`<https://www.w3.org/TR/xml>`]
     V10,
-    /// Version 1.1 [https://www.w3.org/TR/xml11]
+    /// Version 1.1 [`<https://www.w3.org/TR/xml11>`]
     V11,
 }
 

--- a/src/level2/ext/mod.rs
+++ b/src/level2/ext/mod.rs
@@ -23,4 +23,3 @@ pub(crate) mod traits;
 pub use traits::*;
 
 pub(crate) mod trait_impls;
-pub use trait_impls::*;

--- a/src/level2/ext/namespaced.rs
+++ b/src/level2/ext/namespaced.rs
@@ -46,8 +46,8 @@ impl NamespacePrefix {
     ///
     /// Construct a new `NamespacePrefix::Some` value with the provided prefix.
     ///
-    pub fn new_some(prefix: &str) -> Self {
-        Self::Some(prefix.to_string())
+    pub fn new_some(prefix: impl Into<String>) -> Self {
+        Self::Some(prefix.into())
     }
 
     ///

--- a/src/level2/ext/namespaced.rs
+++ b/src/level2/ext/namespaced.rs
@@ -334,8 +334,8 @@ mod tests {
         // prefix
         let ns_result = Some(XSD.to_string());
 
-        assert_eq!(namespaced.contains_mapping(None), false);
-        assert_eq!(namespaced.contains_mapping(Some("xsd")), true);
+        assert!(!namespaced.contains_mapping(None));
+        assert!(namespaced.contains_mapping(Some("xsd")));
         assert_eq!(namespaced.get_namespace(None), None);
         assert_eq!(namespaced.get_namespace(Some("xsd")), ns_result);
         assert_eq!(namespaced.resolve_namespace(None), None);
@@ -344,8 +344,8 @@ mod tests {
         // namespace
         let prefix_result = NamespacePrefix::new_some("xsd");
 
-        assert_eq!(namespaced.contains_mapped_namespace(HTML), false);
-        assert_eq!(namespaced.contains_mapped_namespace(XSD), true);
+        assert!(!namespaced.contains_mapped_namespace(HTML));
+        assert!(namespaced.contains_mapped_namespace(XSD));
         assert_eq!(namespaced.get_prefix(XSD), prefix_result);
         assert_eq!(namespaced.resolve_prefix(XSD), prefix_result);
     }
@@ -362,8 +362,8 @@ mod tests {
         // prefix
         let ns_result = Some(XSD.to_string());
 
-        assert_eq!(namespaced.contains_mapping(None), true);
-        assert_eq!(namespaced.contains_mapping(Some("xsd")), false);
+        assert!(namespaced.contains_mapping(None));
+        assert!(!namespaced.contains_mapping(Some("xsd")));
         assert_eq!(namespaced.get_namespace(None), ns_result);
         assert_eq!(namespaced.get_namespace(Some("xsd")), None);
         assert_eq!(namespaced.resolve_namespace(None), ns_result);
@@ -372,8 +372,8 @@ mod tests {
         // namespace
         let prefix_result = NamespacePrefix::Default;
 
-        assert_eq!(namespaced.contains_mapped_namespace(HTML), false);
-        assert_eq!(namespaced.contains_mapped_namespace(XSD), true);
+        assert!(!namespaced.contains_mapped_namespace(HTML));
+        assert!(namespaced.contains_mapped_namespace(XSD));
         assert_eq!(namespaced.get_prefix(XSD), prefix_result);
         assert_eq!(namespaced.resolve_prefix(XSD), prefix_result);
     }

--- a/src/level2/ext/namespaced.rs
+++ b/src/level2/ext/namespaced.rs
@@ -54,30 +54,21 @@ impl NamespacePrefix {
     /// Returns `true` of this is a `NamespacePrefix::None` value, otherwise `false`.
     ///
     pub fn is_none(&self) -> bool {
-        match *self {
-            NamespacePrefix::None => true,
-            _ => false,
-        }
+        matches!(*self, NamespacePrefix::None)
     }
 
     ///
     /// Returns `true` of this is a `NamespacePrefix::Default` value, otherwise `false`.
     ///
     pub fn is_default(&self) -> bool {
-        match *self {
-            NamespacePrefix::Default => true,
-            _ => false,
-        }
+        matches!(*self, NamespacePrefix::Default)
     }
 
     ///
     /// Returns `true` of this is a `NamespacePrefix::Some` value, otherwise `false`.
     ///
     pub fn is_some(&self) -> bool {
-        match *self {
-            NamespacePrefix::Some(_) => true,
-            _ => false,
-        }
+        matches!(*self, NamespacePrefix::Some(_))
     }
 
     ///

--- a/src/level2/ext/options.rs
+++ b/src/level2/ext/options.rs
@@ -45,7 +45,7 @@ use std::ops::{BitAnd, BitOr};
 ///     .unwrap();
 /// ```
 ///
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct ProcessingOptions(u8);
 
 // ------------------------------------------------------------------------------------------------
@@ -63,14 +63,6 @@ enum ProcessingOptionFlags {
 
 // ------------------------------------------------------------------------------------------------
 // Implementations
-// ------------------------------------------------------------------------------------------------
-
-impl Default for ProcessingOptions {
-    fn default() -> Self {
-        Self(0)
-    }
-}
-
 // ------------------------------------------------------------------------------------------------
 
 impl Display for ProcessingOptions {

--- a/src/level2/ext/traits.rs
+++ b/src/level2/ext/traits.rs
@@ -13,7 +13,7 @@ use crate::shared::error::Result;
 /// of the XML declaration from the document prolog.
 ///
 /// # Specification
-///  
+///
 /// From XML 1.1 [§2.8 Prolog and Document Type Declaration](https://www.w3.org/TR/xml11/#sec-prolog-dtd)
 /// -- Definition: XML 1.1 documents **must** begin with an **XML declaration** which specifies the
 /// version of XML being used.
@@ -108,13 +108,13 @@ pub trait Namespaced: base::Element {
     ///
     /// Returns the namespace URI associated with the provided `prefix`, `None` if the prefix is not
     /// mapped to a URI for this, and only this, element.
-    ///  
+    ///
     fn get_namespace(&self, prefix: Option<&str>) -> Option<String>;
     ///
     /// Returns the namespace URI associated with the provided `prefix` for this element by looking
     /// up the DOM tree through `parent_node` links. Returns `None` if the prefix is not mapped to a
     /// URI on this, or any parent, element.
-    ///  
+    ///
     fn resolve_namespace(&self, prefix: Option<&str>) -> Option<String>;
 
     ///
@@ -125,12 +125,12 @@ pub trait Namespaced: base::Element {
     ///
     /// Returns the prefix associated with the provided `namespace_uri`, `None` if the namespace
     /// URI is not mapped with a prefix for this, and only this, element.
-    ///  
+    ///
     fn get_prefix(&self, namespace_uri: &str) -> NamespacePrefix;
     ///
     /// Returns the prefix associated with the provided `namespace_uri` for this element by looking
     /// up the DOM tree through `parent_node` links. Returns `None` if the namespace is not mapped
     /// with a prefix for this, or any parent, element.
-    ///  
+    ///
     fn resolve_prefix(&self, namespace_uri: &str) -> NamespacePrefix;
 }

--- a/src/level2/node_impl.rs
+++ b/src/level2/node_impl.rs
@@ -137,22 +137,22 @@ impl NodeImpl {
             },
         }
     }
-    pub(crate) fn new_text(owner_document: WeakRefNode, data: &str) -> Self {
+    pub(crate) fn new_text(owner_document: WeakRefNode, data: impl Into<String>) -> Self {
         Self {
             i_node_type: NodeType::Text,
             i_name: Name::for_text(),
-            i_value: Some(data.to_string()),
+            i_value: Some(data.into()),
             i_parent_node: None,
             i_owner_document: Some(owner_document),
             i_child_nodes: vec![],
             i_extension: Extension::None,
         }
     }
-    pub(crate) fn new_cdata(owner_document: WeakRefNode, data: &str) -> Self {
+    pub(crate) fn new_cdata(owner_document: WeakRefNode, data: impl Into<String>) -> Self {
         Self {
             i_node_type: NodeType::CData,
             i_name: Name::for_cdata(),
-            i_value: Some(data.to_string()),
+            i_value: Some(data.into()),
             i_parent_node: None,
             i_owner_document: Some(owner_document),
             i_child_nodes: vec![],
@@ -174,11 +174,11 @@ impl NodeImpl {
             i_extension: Extension::None,
         }
     }
-    pub(crate) fn new_comment(owner_document: WeakRefNode, data: &str) -> Self {
+    pub(crate) fn new_comment(owner_document: WeakRefNode, data: impl Into<String>) -> Self {
         Self {
             i_node_type: NodeType::Comment,
             i_name: Name::for_comment(),
-            i_value: Some(data.to_string()),
+            i_value: Some(data.into()),
             i_parent_node: None,
             i_owner_document: Some(owner_document),
             i_child_nodes: vec![],
@@ -269,12 +269,12 @@ impl NodeImpl {
     pub(crate) fn new_internal_entity(
         owner_document: Option<WeakRefNode>,
         notation_name: Name,
-        value: &str,
+        value: impl Into<String>,
     ) -> Self {
         Self {
             i_node_type: NodeType::Entity,
             i_name: notation_name,
-            i_value: Some(value.to_string()),
+            i_value: Some(value.into()),
             i_parent_node: None,
             i_owner_document: owner_document,
             i_child_nodes: vec![],

--- a/src/level2/node_impl.rs
+++ b/src/level2/node_impl.rs
@@ -304,7 +304,7 @@ impl NodeImpl {
             },
         }
     }
-    #[allow(clippy::clone_double_ref)]
+    #[allow(suspicious_double_ref_op)]
     pub(crate) fn clone_node(&self, deep: bool) -> Self {
         let extension = match &self.i_extension {
             Extension::None => Extension::None,

--- a/src/level2/trait_impls.rs
+++ b/src/level2/trait_impls.rs
@@ -91,12 +91,12 @@ impl Attribute for RefNode {
                     //
                     let ref_node = child_node.borrow();
                     if let Some(data) = &ref_node.i_value {
-                        result.push_str(&data);
+                        result.push_str(data);
                     }
                 }
             }
             let normalized = text::normalize_attribute_value(&result, self, false);
-            Some(text::escape(&normalized))
+            Some(text::escape(normalized))
         } else {
             None
         }
@@ -234,7 +234,7 @@ impl Document for RefNode {
     }
 
     fn document_element(&self) -> Option<RefNode> {
-        self.child_nodes().first().map(Clone::clone)
+        self.child_nodes().first().cloned()
     }
 
     fn implementation(&self) -> &dyn DOMImplementation<NodeRef = RefNode> {
@@ -686,7 +686,7 @@ impl Element for RefNode {
                     None => None,
                     Some(s) => Some(s.as_str()),
                 },
-                &ref_self.i_name.local_name(),
+                ref_self.i_name.local_name(),
                 &namespace_uri,
                 &local_name,
             ) {
@@ -1076,7 +1076,7 @@ impl Node for RefNode {
                     }
                 } else if let Some(last_child_node) = child_node.previous_sibling() {
                     let last_child_node = &mut last_child_node.clone();
-                    if is_text(&last_child_node) {
+                    if is_text(last_child_node) {
                         if last_child_node
                             .append_data(&child_node.node_value().unwrap())
                             .is_err()

--- a/src/level2/trait_impls.rs
+++ b/src/level2/trait_impls.rs
@@ -988,7 +988,7 @@ impl Node for RefNode {
             if is_document(self) {
                 mut_child.i_owner_document = Some(self.clone().downgrade());
             } else {
-                mut_child.i_owner_document = ref_self.i_owner_document.clone();
+                mut_child.i_owner_document.clone_from(&ref_self.i_owner_document);
             }
         }
 

--- a/src/level2/trait_impls.rs
+++ b/src/level2/trait_impls.rs
@@ -988,7 +988,9 @@ impl Node for RefNode {
             if is_document(self) {
                 mut_child.i_owner_document = Some(self.clone().downgrade());
             } else {
-                mut_child.i_owner_document.clone_from(&ref_self.i_owner_document);
+                mut_child
+                    .i_owner_document
+                    .clone_from(&ref_self.i_owner_document);
             }
         }
 
@@ -1266,55 +1268,54 @@ fn is_child_allowed(parent: &RefNode, child: &RefNode) -> bool {
     let self_node_type = { &parent.borrow().i_node_type };
     let child_node_type = { &child.borrow().i_node_type };
     match self_node_type {
-        NodeType::Element => match child_node_type {
+        NodeType::Element => matches!(
+            child_node_type,
             NodeType::Element
-            | NodeType::Text
-            | NodeType::Comment
-            | NodeType::ProcessingInstruction
-            | NodeType::CData
-            | NodeType::EntityReference => true,
-            _ => false,
-        },
-        NodeType::Attribute => match child_node_type {
-            NodeType::Text | NodeType::EntityReference => true,
-            _ => false,
-        },
+                | NodeType::Text
+                | NodeType::Comment
+                | NodeType::ProcessingInstruction
+                | NodeType::CData
+                | NodeType::EntityReference
+        ),
+        NodeType::Attribute => {
+            matches!(child_node_type, NodeType::Text | NodeType::EntityReference)
+        }
         NodeType::Text => false,
         NodeType::CData => false,
-        NodeType::EntityReference => match child_node_type {
+        NodeType::EntityReference => matches!(
+            child_node_type,
             NodeType::Element
-            | NodeType::Text
-            | NodeType::Comment
-            | NodeType::ProcessingInstruction
-            | NodeType::CData
-            | NodeType::EntityReference => true,
-            _ => false,
-        },
-        NodeType::Entity => match child_node_type {
+                | NodeType::Text
+                | NodeType::Comment
+                | NodeType::ProcessingInstruction
+                | NodeType::CData
+                | NodeType::EntityReference
+        ),
+        NodeType::Entity => matches!(
+            child_node_type,
             NodeType::Element
-            | NodeType::Text
-            | NodeType::Comment
-            | NodeType::ProcessingInstruction
-            | NodeType::CData
-            | NodeType::EntityReference => true,
-            _ => false,
-        },
+                | NodeType::Text
+                | NodeType::Comment
+                | NodeType::ProcessingInstruction
+                | NodeType::CData
+                | NodeType::EntityReference
+        ),
         NodeType::ProcessingInstruction => false,
         NodeType::Comment => false,
-        NodeType::Document => match child_node_type {
-            NodeType::Element | NodeType::Comment | NodeType::ProcessingInstruction => true,
-            _ => false,
-        },
+        NodeType::Document => matches!(
+            child_node_type,
+            NodeType::Element | NodeType::Comment | NodeType::ProcessingInstruction
+        ),
         NodeType::DocumentType => false,
-        NodeType::DocumentFragment => match child_node_type {
+        NodeType::DocumentFragment => matches!(
+            child_node_type,
             NodeType::Element
-            | NodeType::Text
-            | NodeType::Comment
-            | NodeType::ProcessingInstruction
-            | NodeType::CData
-            | NodeType::EntityReference => true,
-            _ => false,
-        },
+                | NodeType::Text
+                | NodeType::Comment
+                | NodeType::ProcessingInstruction
+                | NodeType::CData
+                | NodeType::EntityReference
+        ),
         NodeType::Notation => false,
     }
 }

--- a/src/level2/traits.rs
+++ b/src/level2/traits.rs
@@ -384,9 +384,9 @@ pub trait Document: Node {
     ///   character.
     /// * `NAMESPACE_ERR`: Raised if the `qualifiedName` is malformed, if the `qualifiedName` has
     ///   a `prefix` and the `namespaceURI` is `null`, if the `qualifiedName` has a `prefix` that
-    ///   is "xml" and the `namespaceURI` is different from "http://www.w3.org/XML/1998/namespace",
+    ///   is "xml" and the `namespaceURI` is different from `<http://www.w3.org/XML/1998/namespace>`,
     ///   or if the `qualifiedName` is "xmlns" and the namespaceURI is different from
-    ///   "http://www.w3.org/2000/xmlns/".
+    ///   `<http://www.w3.org/2000/xmlns/>`.
     ///
     fn create_attribute_ns(
         &self,
@@ -523,9 +523,9 @@ pub trait Document: Node {
     ///   character.
     /// * `NAMESPACE_ERR`: Raised if the `qualifiedName` is malformed, if the `qualifiedName` has
     ///   a `prefix` and the `namespaceURI` is `null`, if the `qualifiedName` has a `prefix` that
-    ///   is "xml" and the `namespaceURI` is different from "http://www.w3.org/XML/1998/namespace",
+    ///   is "xml" and the `namespaceURI` is different from `<http://www.w3.org/XML/1998/namespace`>,
     ///   or if the `qualifiedName` is "xmlns" and the namespaceURI is different from
-    ///   "http://www.w3.org/2000/xmlns/".
+    ///   `<http://www.w3.org/2000/xmlns/>`.
     ///
     fn create_element_ns(&self, namespace_uri: &str, qualified_name: &str)
         -> Result<Self::NodeRef>;
@@ -785,7 +785,7 @@ pub trait DOMImplementation {
     /// * `INVALID_CHARACTER_ERR`: Raised if the specified qualified name contains an illegal character.
     /// * `NAMESPACE_ERR`: Raised if the qualifiedName is malformed, if the qualifiedName has a prefix
     ///   and the namespaceURI is null, or if the qualifiedName has a prefix that is "xml" and the
-    ///   namespaceURI is different from "http://www.w3.org/XML/1998/namespace".
+    ///   namespaceURI is different from <`http://www.w3.org/XML/1998/namespace>`.
     /// * `WRONG_DOCUMENT_ERR`: Raised if doctype has already been used with a different document or
     ///   was created from a different implementation.
     ///
@@ -1090,9 +1090,9 @@ pub trait Element: Node {
     /// * `NO_MODIFICATION_ALLOWED_ERR`: Raised if this node is readonly.
     /// * `NAMESPACE_ERR`: Raised if the `qualifiedName` is malformed, if the `qualifiedName` has a
     ///   prefix and the `namespaceURI` is null, if the `qualifiedName` has a prefix that is "xml"
-    ///   and the `namespaceURI` is different from "http://www.w3.org/XML/1998/namespace", or if
+    ///   and the `namespaceURI` is different from '<http://www.w3.org/XML/1998/namespace>', or if
     ///   the `qualifiedName` is "xmlns" and the `namespaceURI` is different from
-    /// "http://www.w3.org/2000/xmlns/".
+    /// `<http://www.w3.org/2000/xmlns/>`.
     ///
     fn set_attribute_ns(
         &mut self,
@@ -1687,9 +1687,9 @@ pub trait Node {
     /// * `NO_MODIFICATION_ALLOWED_ERR`: Raised if this node is readonly.
     /// * `NAMESPACE_ERR`: Raised if the specified prefix is malformed, if the `namespaceURI` of this
     ///   node is `null`, if the specified prefix is "xml" and the namespaceURI of this node is
-    ///   different from "http://www.w3.org/XML/1998/namespace", if this node is an attribute and
-    ///   the specified prefix is "xmlns" and the namespaceURI of this node is different from  
-    ///   "http://www.w3.org/2000/xmlns/", or if this node is an attribute and the `qualifiedName`
+    ///   different from `<http://www.w3.org/XML/1998/namespace>`, if this node is an attribute and
+    ///   the specified prefix is "xmlns" and the namespaceURI of this node is different from
+    ///   `<http://www.w3.org/2000/xmlns/>`, or if this node is an attribute and the `qualifiedName`
     ///   of this node is "xmlns".
     ///
     fn prefix(&self) -> Option<String> {

--- a/src/level2/traits.rs
+++ b/src/level2/traits.rs
@@ -162,7 +162,7 @@ pub trait CharacterData: Node {
         ) {
             (None, _) => None,
             (v @ Some(_), false) => v,
-            (Some(value), true) => Some(text::escape(&value)),
+            (Some(value), true) => Some(text::escape(value)),
         }
     }
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ Currently only one feature, `quick_parser`, is provided which provides a new mod
 single public function. This feature is enabled by default.
 
 ``` rust,ignore
-pub fn read_xml(xml: &str) -> Result<RefNode>;
+pub fn read_xml(xml: AsRef<str>) -> Result<RefNode>;
 ```
 
 This will parse the document and return a new `RefNode` that corresponds to the `Document` trait.

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -48,16 +48,10 @@ pub enum Error {
     Malformed,
     /// Errors passed through from DOMError
     #[error("DOM error: {0}")]
-    DOMError(
-        #[from]
-        DOMError
-    ),
+    DOMError(#[from] DOMError),
     /// Errors passed through from quick-xml
     #[error("quick-xml error: {0}")]
-    QuickXMLError(
-        #[from]
-        quick_xml::Error
-    ),
+    QuickXMLError(#[from] quick_xml::Error),
 }
 
 ///

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -155,7 +155,7 @@ fn document<T: BufRead>(reader: &mut Reader<T>, event_buffer: &mut Vec<u8>) -> R
                 let _safe_to_ignore = handle_end(reader, &mut document, None, ev)?;
             }
             Ok(Event::Comment(ev)) => {
-                let _safe_to_ignore = handle_comment(reader, &mut document, None, ev)?;
+                let _safe_to_ignore = handle_comment(&mut document, None, ev)?;
             }
             Ok(Event::PI(ev)) => {
                 let _safe_to_ignore = handle_pi(reader, &mut document, None, ev)?;
@@ -215,13 +215,13 @@ fn element<T: BufRead>(
                 return Ok(parent_element.clone());
             }
             Ok(Event::Comment(ev)) => {
-                let _safe_to_ignore = handle_comment(reader, document, Some(parent_element), ev)?;
+                let _safe_to_ignore = handle_comment(document, Some(parent_element), ev)?;
             }
             Ok(Event::PI(ev)) => {
                 let _safe_to_ignore = handle_pi(reader, document, Some(parent_element), ev)?;
             }
             Ok(Event::Text(ev)) => {
-                let _safe_to_ignore = handle_text(reader, document, Some(parent_element), ev)?;
+                let _safe_to_ignore = handle_text(document, Some(parent_element), ev)?;
             }
             Ok(Event::CData(ev)) => {
                 let _safe_to_ignore = handle_cdata(reader, document, Some(parent_element), ev)?;
@@ -283,14 +283,13 @@ fn handle_end<T: BufRead>(
     .clone())
 }
 
-fn handle_comment<T: BufRead>(
-    reader: &mut Reader<T>,
+fn handle_comment(
     document: &mut RefNode,
     parent_node: Option<&mut RefNode>,
     ev: BytesText<'_>,
 ) -> Result<RefNode> {
     let mut_document = as_document_mut(document).unwrap();
-    let text = make_text(reader, ev)?;
+    let text = make_text(ev)?;
     let new_node = mut_document.create_comment(&text);
     let actual_parent = match parent_node {
         None => document,
@@ -299,14 +298,13 @@ fn handle_comment<T: BufRead>(
     actual_parent.append_child(new_node).map_err(|e| e.into())
 }
 
-fn handle_text<T: BufRead>(
-    reader: &mut Reader<T>,
+fn handle_text(
     document: &mut RefNode,
     parent_node: Option<&mut RefNode>,
     ev: BytesText<'_>,
 ) -> Result<RefNode> {
     let mut_document = as_document_mut(document).unwrap();
-    let text = make_text(reader, ev)?;
+    let text = make_text(ev)?;
     let new_node = mut_document.create_text_node(&text);
     let actual_parent = match parent_node {
         None => document,
@@ -369,7 +367,7 @@ fn handle_pi<T: BufRead>(
 
 // ------------------------------------------------------------------------------------------------
 
-fn make_text<T: BufRead>(reader: &mut Reader<T>, ev: BytesText<'_>) -> Result<String> {
+fn make_text(ev: BytesText<'_>) -> Result<String> {
     Ok(ev.unescape()?.to_string())
 }
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -79,9 +79,9 @@ pub fn read_reader<B: BufRead>(reader: B) -> Result<RefNode> {
     inner_read(&mut Reader::from_reader(reader))
 }
 
-impl<T> Into<Result<T>> for Error {
-    fn into(self) -> Result<T> {
-        Err(self)
+impl<T> From<Error> for Result<T> {
+    fn from(val: Error) -> Self {
+        Err(val)
     }
 }
 

--- a/src/shared/display.rs
+++ b/src/shared/display.rs
@@ -11,11 +11,11 @@ use std::fmt::{Formatter, Result as FmtResult};
 pub(crate) fn fmt_element(element: RefElement<'_>, f: &mut Formatter<'_>) -> FmtResult {
     write!(f, "{}{}", XML_ELEMENT_START_START, element.node_name())?;
     for attr in element.attributes().values() {
-        write!(f, " {}", attr.to_string())?;
+        write!(f, " {}", attr)?;
     }
     write!(f, "{}", XML_ELEMENT_START_END)?;
     for child in element.child_nodes() {
-        write!(f, "{}", child.to_string())?;
+        write!(f, "{}", child)?;
     }
     write!(
         f,
@@ -77,7 +77,7 @@ pub(crate) fn fmt_document(document: RefDocumentDecl<'_>, f: &mut Formatter<'_>)
         write!(f, "{}", doc_type)?;
     }
     for child in document.child_nodes() {
-        write!(f, "{}", child.to_string())?;
+        write!(f, "{}", child)?;
     }
     Ok(())
 }
@@ -114,7 +114,7 @@ pub(crate) fn fmt_document_fragment(
 ) -> FmtResult {
     write!(f, "{}{} ", XML_CDATA_START, fragment.node_name())?;
     for child in fragment.child_nodes() {
-        write!(f, "{}", child.to_string())?;
+        write!(f, "{}", child)?;
     }
     write!(f, "{}", XML_CDATA_END)
 }

--- a/src/shared/error.rs
+++ b/src/shared/error.rs
@@ -136,8 +136,8 @@ impl Display for Error {
 
 impl std::error::Error for Error {}
 
-impl<T> Into<Result<T>> for Error {
-    fn into(self) -> Result<T> {
-        Err(self)
+impl<T> From<Error> for Result<T> {
+    fn from(val: Error) -> Self {
+        Err(val)
     }
 }

--- a/src/shared/name.rs
+++ b/src/shared/name.rs
@@ -187,19 +187,21 @@ impl Name {
         let local = local.as_ref();
 
         if namespace_uri.is_empty() {
-            return Err(Error::Syntax)
+            return Err(Error::Syntax);
         }
 
         if let Some(prefix) = prefix {
             if (prefix == XML_NS_ATTRIBUTE && namespace_uri != XML_NS_URI)
-                || (prefix == XMLNS_NS_ATTRIBUTE && namespace_uri != XMLNS_NS_URI) {
+                || (prefix == XMLNS_NS_ATTRIBUTE && namespace_uri != XMLNS_NS_URI)
+            {
                 return Err(Error::Namespace);
             }
         }
 
         if (local == XML_NS_ATTRIBUTE && namespace_uri != XML_NS_URI)
-            || (local == XMLNS_NS_ATTRIBUTE && namespace_uri != XMLNS_NS_URI) {
-            return Err(Error::Namespace)
+            || (local == XMLNS_NS_ATTRIBUTE && namespace_uri != XMLNS_NS_URI)
+        {
+            return Err(Error::Namespace);
         }
 
         Ok(namespace_uri.to_string())

--- a/src/shared/name.rs
+++ b/src/shared/name.rs
@@ -88,10 +88,10 @@ impl FromStr for Name {
                 .map(|s| s.to_string())
                 .collect::<Vec<String>>();
             match parts.len() {
-                1 => Name::new(Name::check_part(parts.get(0).unwrap())?, None, None),
+                1 => Name::new(Name::check_part(parts.first().unwrap())?, None, None),
                 2 => Name::new(
                     Name::check_part(parts.get(1).unwrap())?,
-                    Some(Name::check_part(parts.get(0).unwrap())?),
+                    Some(Name::check_part(parts.first().unwrap())?),
                     None,
                 ),
                 _ => Err(Error::Syntax),
@@ -303,7 +303,7 @@ impl Name {
         let xmlns_ns = Some(XMLNS_NS_URI.to_string());
         let xmlns_attribute = XMLNS_NS_ATTRIBUTE.to_string();
         self.namespace_uri == xmlns_ns
-            && ((self.local_name == xmlns_attribute && self.prefix == None)
+            && ((self.local_name == xmlns_attribute && self.prefix.is_none())
                 || self.prefix == Some(xmlns_attribute))
     }
 

--- a/src/shared/name.rs
+++ b/src/shared/name.rs
@@ -49,9 +49,9 @@ use std::str::{from_utf8, FromStr};
 /// > * `NO_MODIFICATION_ALLOWED_ERR`: Raised if this node is readonly.
 /// > * `NAMESPACE_ERR`: Raised if the specified prefix is malformed, if the namespaceURI of this
 /// >   node is null, if the specified prefix is "xml" and the namespaceURI of this node is
-/// >   different from "http://www.w3.org/XML/1998/namespace", if this node is an attribute and the
+/// >   different from `<http://www.w3.org/XML/1998/namespace>`, if this node is an attribute and the
 /// >   specified prefix is "xmlns" and the namespaceURI of this node is different from
-/// >   "http://www.w3.org/2000/xmlns/", or if this node is an attribute and the qualifiedName of
+/// >   `<http://www.w3.org/2000/xmlns/>`, or if this node is an attribute and the qualifiedName of
 /// >   this node is "xmlns".
 ///
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]

--- a/src/shared/rc_cell.rs
+++ b/src/shared/rc_cell.rs
@@ -89,10 +89,7 @@ impl<T> WeakRefCell<T> {
     }
 
     pub fn upgrade(self) -> Option<RcRefCell<T>> {
-        match self.inner.upgrade() {
-            None => None,
-            Some(inner) => Some(RcRefCell { inner }),
-        }
+        self.inner.upgrade().map(|inner| RcRefCell { inner })
     }
 }
 

--- a/src/shared/text.rs
+++ b/src/shared/text.rs
@@ -262,9 +262,9 @@ pub(crate) fn is_xml_10_char(c: char) -> bool {
     c == '\u{0009}'
         || c == '\u{000A}'
         || c == '\u{000D}'
-        || (c >= '\u{0020}' && c <= '\u{D7FF}')
-        || (c >= '\u{E000}' && c <= '\u{FFFD}')
-        || (c >= '\u{10000}' && c <= '\u{10FFF}')
+        || ('\u{0020}'..='\u{D7FF}').contains(&c)
+        || ('\u{E000}'..='\u{FFFD}').contains(&c)
+        || ('\u{10000}'..='\u{10FFF}').contains(&c)
 }
 
 #[allow(dead_code)]
@@ -290,9 +290,9 @@ pub(crate) fn is_xml_11_char(c: char) -> bool {
     // below ranges are always valid for XML 1.1 documents
     // from https://en.wikipedia.org/wiki/XML#Valid_characters
     //
-    (c >= '\u{0001}' && c <= '\u{D7FF}')
-        || (c >= '\u{E000}' && c <= '\u{FFFD}')
-        || (c >= '\u{10000}' && c <= '\u{10FFF}')
+    ('\u{0001}'..='\u{D7FF}').contains(&c)
+        || ('\u{E000}'..='\u{FFFD}').contains(&c)
+        || ('\u{10000}'..='\u{10FFF}').contains(&c)
 }
 
 ///
@@ -308,11 +308,11 @@ pub(crate) fn is_xml_11_restricted_char(c: char) -> bool {
     // below ranges are always valid for XML 1.1 documents
     // from https://en.wikipedia.org/wiki/XML#Valid_characters
     //
-    (c >= '\u{01}' && c <= '\u{08}')
-        || (c >= '\u{0B}' && c <= '\u{0C}')
-        || (c >= '\u{0E}' && c <= '\u{1F}')
-        || (c >= '\u{7F}' && c <= '\u{84}')
-        || (c >= '\u{86}' && c <= '\u{9F}')
+    ('\u{01}'..='\u{08}').contains(&c)
+        || ('\u{0B}'..='\u{0C}').contains(&c)
+        || ('\u{0E}'..='\u{1F}').contains(&c)
+        || ('\u{7F}'..='\u{84}').contains(&c)
+        || ('\u{86}'..='\u{9F}').contains(&c)
 }
 
 ///
@@ -345,21 +345,21 @@ pub(crate) fn is_xml_space(c: char) -> bool {
 #[allow(dead_code)]
 pub(crate) fn is_xml_name_start_char(c: char) -> bool {
     c == ':'
-        || (c >= 'A' && c <= 'Z')
+        || c.is_ascii_uppercase()
         || c == '_'
-        || (c >= 'a' && c <= 'z')
-        || (c >= '\u{C0}' && c <= '\u{D6}')
-        || (c >= '\u{D8}' && c <= '\u{F6}')
-        || (c >= '\u{0F8}' && c <= '\u{2FF}')
-        || (c >= '\u{370}' && c <= '\u{37D}')
-        || (c >= '\u{037F}' && c <= '\u{1FFF}')
-        || (c >= '\u{200C}' && c <= '\u{200D}')
-        || (c >= '\u{2070}' && c <= '\u{218F}')
-        || (c >= '\u{2C00}' && c <= '\u{2FEF}')
-        || (c >= '\u{3001}' && c <= '\u{D7FF}')
-        || (c >= '\u{F900}' && c <= '\u{FDCF}')
-        || (c >= '\u{FDF0}' && c <= '\u{FFFD}')
-        || (c >= '\u{10000}' && c <= '\u{EFFFF}')
+        || c.is_ascii_lowercase()
+        || ('\u{C0}'..='\u{D6}').contains(&c)
+        || ('\u{D8}'..='\u{F6}').contains(&c)
+        || ('\u{0F8}'..='\u{2FF}').contains(&c)
+        || ('\u{370}'..='\u{37D}').contains(&c)
+        || ('\u{037F}'..='\u{1FFF}').contains(&c)
+        || ('\u{200C}'..='\u{200D}').contains(&c)
+        || ('\u{2070}'..='\u{218F}').contains(&c)
+        || ('\u{2C00}'..='\u{2FEF}').contains(&c)
+        || ('\u{3001}'..='\u{D7FF}').contains(&c)
+        || ('\u{F900}'..='\u{FDCF}').contains(&c)
+        || ('\u{FDF0}'..='\u{FFFD}').contains(&c)
+        || ('\u{10000}'..='\u{EFFFF}').contains(&c)
 }
 
 ///
@@ -372,10 +372,10 @@ pub(crate) fn is_xml_name_char(c: char) -> bool {
     is_xml_name_start_char(c)
         || c == '-'
         || c == '.'
-        || (c >= '0' && c <= '9')
+        || c.is_ascii_digit()
         || c == '\u{B7}'
-        || (c >= '\u{0300}' && c <= '\u{036F}')
-        || (c >= '\u{203F}' && c <= '\u{2040}')
+        || ('\u{0300}'..='\u{036F}').contains(&c)
+        || ('\u{203F}'..='\u{2040}').contains(&c)
 }
 
 ///
@@ -508,7 +508,7 @@ mod tests {
     #[test]
     fn test_end_of_line_handling() {
         let input = "one\u{0D}two\u{0D}\u{0A}\u{0A}three\u{0A}\u{0D}\u{85}four\u{85}five\u{2028}";
-        let output = normalize_end_of_lines(&input.to_string());
+        let output = normalize_end_of_lines(input);
         assert_eq!(
             output,
             "one\u{0A}two\u{0A}\u{0A}three\u{0A}\u{0A}four\u{0A}five\u{0A}".to_string()

--- a/src/shared/text.rs
+++ b/src/shared/text.rs
@@ -1,5 +1,4 @@
 use crate::shared::syntax::*;
-use std::convert::TryFrom;
 use std::fmt::{Display, Formatter, Result as FmtResult};
 use std::str::FromStr;
 
@@ -61,10 +60,11 @@ pub(crate) trait EntityResolver {
 /// has been read.
 ///
 pub(crate) fn normalize_attribute_value(
-    value: &str,
+    value: impl AsRef<str>,
     resolver: &dyn EntityResolver,
     is_cdata: bool,
 ) -> String {
+    let value = value.as_ref();
     let step_1 = normalize_end_of_lines(value);
     let step_3 = if step_1.is_empty() {
         step_1
@@ -137,7 +137,8 @@ pub(crate) fn normalize_attribute_value(
 /// encoding declaration (if present) has been read. Therefore, it is a fatal error to use them
 /// within the XML declaration or text declaration.
 ///
-pub(crate) fn normalize_end_of_lines(value: &str) -> String {
+pub(crate) fn normalize_end_of_lines(value: impl AsRef<str>) -> String {
+    let value = value.as_ref();
     if value.is_empty() {
         value.to_string()
     } else {
@@ -178,7 +179,8 @@ pub(crate) fn normalize_end_of_lines(value: &str) -> String {
 /// single-quote character (') may be represented as "&apos;", and the double-quote character (")
 /// as "&quot;".
 ///
-pub(crate) fn escape(input: &str) -> String {
+pub(crate) fn escape(input: impl AsRef<str>) -> String {
+    let input = input.as_ref();
     let mut result = String::with_capacity(input.len());
 
     for c in input.chars() {
@@ -209,7 +211,8 @@ pub(crate) fn to_entity_hex(c: char) -> String {
     )
 }
 
-fn char_from_entity(entity: &str) -> String {
+fn char_from_entity(entity: impl AsRef<str>) -> String {
+    let entity = entity.as_ref();
     assert!(entity.starts_with("&#"));
     assert!(entity.ends_with(';'));
     let code_point = if &entity[2..3] == "x" {
@@ -379,7 +382,8 @@ pub(crate) fn is_xml_name_char(c: char) -> bool {
 /// Name   ::=  NameStartChar (NameChar)*
 /// ```
 ///
-pub(crate) fn is_xml_name(s: &str) -> bool {
+pub(crate) fn is_xml_name(s: impl AsRef<str>) -> bool {
+    let s = s.as_ref();
     !s.is_empty() && s.starts_with(is_xml_name_start_char) && s[1..].chars().all(is_xml_name_char)
 }
 
@@ -389,7 +393,8 @@ pub(crate) fn is_xml_name(s: &str) -> bool {
 /// ```
 ///
 #[allow(dead_code)]
-pub(crate) fn is_xml_names(s: &str) -> bool {
+pub(crate) fn is_xml_names(s: impl AsRef<str>) -> bool {
+    let s = s.as_ref();
     !s.is_empty() && s.split(' ').all(is_xml_name)
 }
 
@@ -399,7 +404,8 @@ pub(crate) fn is_xml_names(s: &str) -> bool {
 /// ```
 ///
 #[allow(dead_code)]
-pub(crate) fn is_xml_nmtoken(s: &str) -> bool {
+pub(crate) fn is_xml_nmtoken(s: impl AsRef<str>) -> bool {
+    let s = s.as_ref();
     !s.is_empty() && s.chars().all(is_xml_name_char)
 }
 
@@ -409,7 +415,8 @@ pub(crate) fn is_xml_nmtoken(s: &str) -> bool {
 /// ```
 ///
 #[allow(dead_code)]
-pub(crate) fn is_xml_nmtokens(s: &str) -> bool {
+pub(crate) fn is_xml_nmtokens(s: impl AsRef<str>) -> bool {
+    let s = s.as_ref();
     !s.is_empty() && s.split(' ').all(is_xml_nmtoken)
 }
 

--- a/src/shared/text.rs
+++ b/src/shared/text.rs
@@ -6,8 +6,9 @@ use std::str::FromStr;
 //  Public Types
 // ------------------------------------------------------------------------------------------------
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub(crate) enum SpaceHandling {
+    #[default]
     Default,
     Preserve,
 }
@@ -422,14 +423,6 @@ pub(crate) fn is_xml_nmtokens(s: impl AsRef<str>) -> bool {
 
 // ------------------------------------------------------------------------------------------------
 // Implementations
-// ------------------------------------------------------------------------------------------------
-
-impl Default for SpaceHandling {
-    fn default() -> Self {
-        SpaceHandling::Default
-    }
-}
-
 // ------------------------------------------------------------------------------------------------
 
 impl Display for SpaceHandling {

--- a/src/shared/text.rs
+++ b/src/shared/text.rs
@@ -221,7 +221,7 @@ fn char_from_entity(entity: impl AsRef<str>) -> String {
         u32::from_str_radix(code_point, 16).unwrap()
     } else {
         let code_point = &entity[2..entity.len() - 1];
-        u32::from_str_radix(code_point, 10).unwrap()
+        code_point.parse::<u32>().unwrap()
     };
     let character = char::try_from(code_point).unwrap();
     character.to_string()

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -197,7 +197,7 @@ fn test_display_document_type() {
 #[test]
 fn test_display_document_fragment() {
     let implementation = get_implementation();
-    let mut document_node = implementation
+    let document_node = implementation
         .create_document(Some(common::RDF_NS), Some("rdf:RDF"), None)
         .unwrap();
     let document = as_document(&document_node).unwrap();

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -205,7 +205,7 @@ fn test_display_document_fragment() {
     let mut test_node = document.create_document_fragment().unwrap();
     let mut_fragment = as_document_fragment_mut(&mut test_node).unwrap();
 
-    for name in vec!["one", "two", "three"] {
+    for name in ["one", "two", "three"] {
         let node = document.create_element(name).unwrap();
         let _safe_to_ignore = mut_fragment.append_child(node).unwrap();
     }

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -200,7 +200,7 @@ fn test_display_document_fragment() {
     let mut document_node = implementation
         .create_document(Some(common::RDF_NS), Some("rdf:RDF"), None)
         .unwrap();
-    let document = as_document(&mut document_node).unwrap();
+    let document = as_document(&document_node).unwrap();
 
     let mut test_node = document.create_document_fragment().unwrap();
     let mut_fragment = as_document_fragment_mut(&mut test_node).unwrap();

--- a/tests/node.rs
+++ b/tests/node.rs
@@ -472,8 +472,9 @@ const ALL_CHILDREN: [NodeType; 12] = [
     NodeType::Notation,
 ];
 
-fn test_parent(document: RefNode, parent_type: NodeType, allowed: &Vec<NodeType>) {
+fn test_parent(document: RefNode, parent_type: NodeType, allowed: impl AsRef<[NodeType]>) {
     let mut parent_node = make_node(document.clone(), parent_type.clone(), "parent");
+    let allowed = allowed.as_ref();
     for child_type in ALL_CHILDREN.iter() {
         common::sub_test(
             "test_is_child_allowed",

--- a/tests/node.rs
+++ b/tests/node.rs
@@ -536,7 +536,11 @@ fn make_sibling_document() -> RefNode {
 }
 
 fn compare_node_names(nodes: impl AsRef<[RefNode]>, expected_names: &[&str]) {
-    let names: Vec<String> = nodes.as_ref().iter().map(|n| n.node_name().to_string()).collect();
+    let names: Vec<String> = nodes
+        .as_ref()
+        .iter()
+        .map(|n| n.node_name().to_string())
+        .collect();
     let expected_names: Vec<String> = expected_names.iter().map(|s| String::from(*s)).collect();
     assert_eq!(names, expected_names);
 }

--- a/tests/node.rs
+++ b/tests/node.rs
@@ -481,13 +481,13 @@ fn test_parent(document: RefNode, parent_type: NodeType, allowed: &Vec<NodeType>
                 "{:?}.append_child({:?}) -> {}?",
                 parent_type,
                 child_type,
-                allowed.contains(&child_type)
+                allowed.contains(child_type)
             ),
         );
         let child_node = make_node(document.clone(), child_type.clone(), "child");
         assert_eq!(
             parent_node.append_child(child_node).is_ok(),
-            allowed.contains(&child_type)
+            allowed.contains(child_type)
         );
     }
 }

--- a/tests/node.rs
+++ b/tests/node.rs
@@ -534,8 +534,8 @@ fn make_sibling_document() -> RefNode {
     document_node
 }
 
-fn compare_node_names(nodes: &Vec<RefNode>, expected_names: &[&str]) {
-    let names: Vec<String> = nodes.iter().map(|n| n.node_name().to_string()).collect();
+fn compare_node_names(nodes: impl AsRef<[RefNode]>, expected_names: &[&str]) {
+    let names: Vec<String> = nodes.as_ref().iter().map(|n| n.node_name().to_string()).collect();
     let expected_names: Vec<String> = expected_names.iter().map(|s| String::from(*s)).collect();
     assert_eq!(names, expected_names);
 }

--- a/tests/text.rs
+++ b/tests/text.rs
@@ -11,12 +11,10 @@ fn test_text_node_contents() {
     //
     // Note, this test character escaping, "&" should be "&#38;" in the tree.
     //
-    let text_values = vec![
-        "Rose Bush",
+    let text_values = ["Rose Bush",
         "A Guide to Growing Roses",
         "Describes process for planting &#38; nurturing different kinds of rose bushes.",
-        "2001-01-20",
-    ];
+        "2001-01-20"];
     let root_node = common::create_example_rdf_document();
     let document = as_document(&root_node).unwrap();
 
@@ -27,11 +25,11 @@ fn test_text_node_contents() {
     let description_element = as_element(&description_node).unwrap();
 
     for (index, child) in description_element.child_nodes().iter().enumerate() {
-        let child_element = as_element(&child).unwrap();
+        let child_element = as_element(child).unwrap();
         let children = child_element.child_nodes();
         assert_eq!(children.len(), 1);
         let text = children.first().unwrap();
-        let text = as_text(&text).unwrap();
+        let text = as_text(text).unwrap();
         assert_eq!(text.data().unwrap(), text_values[index].to_string());
     }
 }
@@ -51,7 +49,7 @@ fn test_text_substring() {
     let children = root_element.child_nodes();
     assert_eq!(children.len(), 1);
 
-    let mut text_node = children.get(0).unwrap().clone();
+    let mut text_node = children.first().unwrap().clone();
     let text = as_text_mut(&mut text_node).unwrap();
     assert_eq!(text.data(), Some("Hello cruel world!".to_string()));
     assert_eq!(text.substring_data(0, 0), Ok("".to_string()));
@@ -75,11 +73,11 @@ fn test_text_insert() {
     let children = root_element.child_nodes();
     assert_eq!(children.len(), 1);
 
-    let mut text_node = children.get(0).unwrap().clone();
+    let mut text_node = children.first().unwrap().clone();
     let text = as_text_mut(&mut text_node).unwrap();
     assert_eq!(text.data(), Some("Hello cruel world!".to_string()));
 
-    let mut text_node = children.get(0).unwrap().clone();
+    let mut text_node = children.first().unwrap().clone();
     let text = as_text_mut(&mut text_node).unwrap();
     let result = text.insert_data(6, "my ");
     assert!(result.is_ok());
@@ -109,11 +107,11 @@ fn test_text_replace() {
     let children = root_element.child_nodes();
     assert_eq!(children.len(), 1);
 
-    let mut text_node = children.get(0).unwrap().clone();
+    let mut text_node = children.first().unwrap().clone();
     let text = as_text_mut(&mut text_node).unwrap();
     assert_eq!(text.data(), Some("Hello cruel world!".to_string()));
 
-    let mut text_node = children.get(0).unwrap().clone();
+    let mut text_node = children.first().unwrap().clone();
     let text = as_text_mut(&mut text_node).unwrap();
     let result = text.replace_data(6, 6, "my happy ");
     assert!(result.is_ok());
@@ -146,11 +144,11 @@ fn test_text_delete() {
     let children = root_element.child_nodes();
     assert_eq!(children.len(), 1);
 
-    let mut text_node = children.get(0).unwrap().clone();
+    let mut text_node = children.first().unwrap().clone();
     let text = as_text_mut(&mut text_node).unwrap();
     assert_eq!(text.data(), Some("Hello cruel world!".to_string()));
 
-    let mut text_node = children.get(0).unwrap().clone();
+    let mut text_node = children.first().unwrap().clone();
     let text = as_text_mut(&mut text_node).unwrap();
     let result = text.delete_data(6, 6);
     assert!(result.is_ok());
@@ -187,15 +185,15 @@ fn test_cdata_split() {
     let children = root_element.child_nodes();
     assert_eq!(children.len(), 1);
 
-    let mut text_node = children.get(0).unwrap().clone();
+    let mut text_node = children.first().unwrap().clone();
     let cdata = as_cdata_section_mut(&mut text_node).unwrap();
     let result = cdata.split(3);
     assert!(result.is_ok());
 
-    let expected = vec!["one", "two"];
+    let expected = ["one", "two"];
     for (index, child_node) in root_element.child_nodes().iter().enumerate() {
         // The following also ensures `node_type == NodeType::CData`
-        let text = as_cdata_section(&child_node).unwrap();
+        let text = as_cdata_section(child_node).unwrap();
         assert_eq!(text.data().unwrap(), expected[index].to_string());
     }
 }
@@ -208,7 +206,7 @@ fn test_text_split() {
     let mut root_node = document.document_element().unwrap();
     let root_element = as_element_mut(&mut root_node).unwrap();
 
-    for content in vec!["onetwo", "threefour", "fivesix"] {
+    for content in ["onetwo", "threefour", "fivesix"] {
         let text_node = document.create_text_node(content);
         let _ignore = root_element.append_child(text_node);
     }
@@ -216,7 +214,7 @@ fn test_text_split() {
     let children = root_element.child_nodes();
     assert_eq!(children.len(), 3);
 
-    let mut text_node = children.get(0).unwrap().clone();
+    let mut text_node = children.first().unwrap().clone();
     let text = as_text_mut(&mut text_node).unwrap();
     let result = text.split(3);
     assert!(result.is_ok());
@@ -240,10 +238,10 @@ fn test_text_split() {
     let children = root_element.child_nodes();
     assert_eq!(children.len(), 6);
 
-    let expected = vec!["one", "two", "", "threefour", "fivesix", ""];
+    let expected = ["one", "two", "", "threefour", "fivesix", ""];
     for (index, child_node) in root_element.child_nodes().iter().enumerate() {
         // The following also ensures `node_type == NodeType::Text`
-        let text = as_text(&child_node).unwrap();
+        let text = as_text(child_node).unwrap();
         assert_eq!(text.data().unwrap(), expected[index].to_string());
     }
 }

--- a/tests/text.rs
+++ b/tests/text.rs
@@ -11,10 +11,12 @@ fn test_text_node_contents() {
     //
     // Note, this test character escaping, "&" should be "&#38;" in the tree.
     //
-    let text_values = ["Rose Bush",
+    let text_values = [
+        "Rose Bush",
         "A Guide to Growing Roses",
         "Describes process for planting &#38; nurturing different kinds of rose bushes.",
-        "2001-01-20"];
+        "2001-01-20",
+    ];
     let root_node = common::create_example_rdf_document();
     let document = as_document(&root_node).unwrap();
 


### PR DESCRIPTION
# Description

Bringing the code up to date, and making a few interfaces a little bit more generic.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Updated the dependencies
- [X] Fixed a bunch of formatting and clippy issues
- [X] Simplified error handling
- [X] Made read_xml() accept an AsRef<str>, making it more generic.
- [X] Fixed some markdown lints in the documentation.

# How Has This Been Tested?

- [x] cargo test

**Environment (please complete the following information):**
 - Platform: Darwin Ericas-Air.lan 23.4.0 Darwin Kernel Version 23.4.0: Fri Mar 15 00:19:22 PDT 2024; root:xnu-10063.101.17~1/RELEASE_ARM64_T8112 arm64
 - Rust rustc 1.80.0-nightly (9c9b56879 2024-05-05)
 - Cargo cargo 1.80.0-nightly (05364cb2f 2024-05-03)

# Checklist:

- [X ] My code follows the style guidelines of this project (e.g. run `cargo fmt`)
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] My changes DO NOT require unstable features without prior agreement
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
